### PR TITLE
Add persistent session tracking and leaderboard support

### DIFF
--- a/cogs/control/leaderboard.py
+++ b/cogs/control/leaderboard.py
@@ -1,0 +1,59 @@
+import discord
+from discord.ext import commands
+from discord import app_commands
+from utils.database import fetch_playtime_leaderboard, server_autocomplete
+
+class LeaderboardCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    def format_duration(self, seconds: int) -> str:
+        """
+        Converts an integer number of seconds to a human-readable string,
+        e.g., "1h 2m 3s" or "13m 19s".
+        """
+        hours = seconds // 3600
+        remainder = seconds % 3600
+        minutes = remainder // 60
+        secs = remainder % 60
+
+        parts = []
+        if hours > 0:
+            parts.append(f"{hours}h")
+        if minutes > 0 or hours > 0:
+            parts.append(f"{minutes}m")
+        parts.append(f"{secs}s")
+        return " ".join(parts)
+
+    async def server_names(self, interaction: discord.Interaction, current: str):
+        """Autocomplete helper for server names based on user input."""
+        guild_id = interaction.guild.id
+        names = await server_autocomplete(guild_id, current)
+        return [app_commands.Choice(name=name, value=name) for name in names]
+
+    @app_commands.command(name="leaderboard", description="Show the playtime leaderboard for a specific server")
+    @app_commands.autocomplete(server=server_names)
+    async def leaderboard(self, interaction: discord.Interaction, server: str):
+        leaderboard_data = await fetch_playtime_leaderboard(server, limit=10)
+        if not leaderboard_data:
+            await interaction.response.send_message(f"No playtime data available yet for server '{server}'.", ephemeral=True)
+            return
+
+        embed = discord.Embed(
+            title=f"Playtime Leaderboard for {server}",
+            color=discord.Color.blue()
+        )
+
+        for idx, (user_id, total_seconds, name) in enumerate(leaderboard_data, start=1):
+            display_name = name if name else user_id
+            duration_str = self.format_duration(total_seconds)
+            embed.add_field(
+                name=f"{idx}. {display_name}",
+                value=duration_str,
+                inline=False
+            )
+
+        await interaction.response.send_message(embed=embed)
+
+async def setup(bot):
+    await bot.add_cog(LeaderboardCog(bot))

--- a/cogs/logging/events.py
+++ b/cogs/logging/events.py
@@ -6,15 +6,35 @@ from utils.database import (
     add_logchannel,
     remove_logchannel,
     fetch_logchannel,
-    server_autocomplete
+    server_autocomplete,
+    update_player_playtime,
+    add_active_session,
+    remove_active_session,
+    load_active_sessions,
+    load_total_playtimes_for_server
 )
 from palworld_api import PalworldAPI
 import logging
+from datetime import timedelta, datetime
+
+def discord_timestamp(dt: datetime, style: str = "f") -> str:
+    """Return a Discord-formatted timestamp. Example: <t:1632105600:f>"""
+    return f"<t:{int(dt.timestamp())}:{style}>"
+
+def format_duration(duration: timedelta) -> str:
+    """Converts a timedelta to a string showing hours, minutes, and seconds."""
+    total_seconds = int(duration.total_seconds())
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    seconds = total_seconds % 60
+    return f"{hours}h {minutes}m {seconds}s"
 
 class EventsCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.player_cache = {}
+        self.active_sessions = {}
+        self.total_playtimes = {}
         self.log_players.start()
 
     def cog_unload(self):
@@ -26,39 +46,84 @@ class EventsCog(commands.Cog):
         for server in servers:
             guild_id, server_name, host, password, api_port, rcon_port = server
             log_channel_id = await fetch_logchannel(guild_id, server_name)
-            if log_channel_id:
-                channel = self.bot.get_channel(log_channel_id)
-                if channel:
-                    try:
-                        api = PalworldAPI(f"http://{host}:{api_port}", "admin", password)
-                        player_list = await api.get_player_list()
-                        current_players = {(player['userId'], player['accountName']) for player in player_list['players']}
+            if not log_channel_id:
+                continue
 
-                        if server_name not in self.player_cache:
-                            self.player_cache[server_name] = current_players
-                            continue
+            channel = self.bot.get_channel(log_channel_id)
+            if not channel:
+                continue
 
-                        old_players = self.player_cache[server_name]
-                        joined_players = current_players - old_players
-                        left_players = old_players - current_players
+            try:
+                api = PalworldAPI(f"http://{host}:{api_port}", "admin", password)
+                player_list = await api.get_player_list()
+                current_players = {(player['userId'], player['accountName']) for player in player_list['players']}
 
-                        for userId, accountName in joined_players:
-                            join_text = f"Player `{accountName} ({userId})` has joined {server_name}."
-                            join = discord.Embed(title="Player Joined", description=join_text , color=discord.Color.green(), timestamp=discord.utils.utcnow())
-                            await channel.send(embed=join)
-                        for userId, accountName in left_players:
-                            left_text = f"Player `{accountName} ({userId})` has left {server_name}."
-                            left = discord.Embed(title="Player Left", description=left_text, color=discord.Color.red(), timestamp=discord.utils.utcnow())
-                            await channel.send(embed=left)
+                if server_name not in self.player_cache:
+                    self.player_cache[server_name] = current_players
+                    self.active_sessions[server_name] = await load_active_sessions(server_name)
+                    self.total_playtimes[server_name] = await load_total_playtimes_for_server(server_name)
 
-                        self.player_cache[server_name] = current_players
-                    except Exception as e:
-                        logging.error(f"Issues logging player on '{server_name}': {str(e)}")
+                old_players = self.player_cache[server_name]
+                joined_players = current_players - old_players
+                left_players = old_players - current_players
+
+                for userId, accountName in joined_players:
+                    now = discord.utils.utcnow()
+                    if server_name not in self.active_sessions:
+                        self.active_sessions[server_name] = {}
+                    self.active_sessions[server_name][userId] = now
+                    await add_active_session(server_name, userId, int(now.timestamp()))
+                    join_time_str = discord_timestamp(now, "f")
+                    join_text = f"Player `{accountName} ({userId})` has joined **{server_name}** at {join_time_str}."
+                    join_embed = discord.Embed(
+                        title="Player Joined",
+                        description=join_text,
+                        color=discord.Color.green(),
+                        timestamp=now
+                    )
+                    await channel.send(embed=join_embed)
+
+                for userId, accountName in left_players:
+                    now = discord.utils.utcnow()
+                    leave_str = discord_timestamp(now, "f")
+                    join_time = self.active_sessions.get(server_name, {}).pop(userId, None)
+                    if join_time:
+                        session_duration = now - join_time
+                        session_str = format_duration(session_duration)
+                        session_seconds = int(session_duration.total_seconds())
+                        await update_player_playtime(server_name, userId, session_seconds)
+                        previous_total = self.total_playtimes[server_name].get(userId, 0)
+                        new_total = previous_total + session_seconds
+                        self.total_playtimes[server_name][userId] = new_total
+                        total_str = format_duration(timedelta(seconds=new_total))
+                        join_time_str = discord_timestamp(join_time, "f")
+                        left_text = (
+                            f"Player `{accountName} ({userId})` has left **{server_name}** at {leave_str}.\n"
+                            f"**Session Duration:** {session_str} (Joined at {join_time_str})\n"
+                            f"**Total Playtime:** {total_str}"
+                        )
+                        # Remove persistent active session.
+                        await remove_active_session(server_name, userId)
+                    else:
+                        left_text = f"Player `{accountName} ({userId})` has left **{server_name}** at {leave_str} (join time not recorded)."
+                    
+                    left_embed = discord.Embed(
+                        title="Player Left",
+                        description=left_text,
+                        color=discord.Color.red(),
+                        timestamp=now
+                    )
+                    await channel.send(embed=left_embed)
+
+                self.player_cache[server_name] = current_players
+
+            except Exception as e:
+                logging.error(f"Issues logging player on '{server_name}': {str(e)}")
 
     @log_players.before_loop
     async def before_log_players(self):
         await self.bot.wait_until_ready()
-        
+
     async def server_names(self, interaction: discord.Interaction, current: str):
         guild_id = interaction.guild.id
         server_names = await server_autocomplete(guild_id, current)


### PR DESCRIPTION
- Introduce `active_sessions` table and helper functions to persist player join times.
- Introduce `player_playtimes` table to track cumulative playtime based on server_name and user_id.
- Load persistent active sessions and cumulative totals on bot startup to ensure data survives restarts.
- Add a new leaderboard command in `cogs/control/leaderboard.py` for server-specific playtime ranking.

![image](https://github.com/user-attachments/assets/f2572d48-0d4f-440d-86a8-c10388d986fa)
![image](https://github.com/user-attachments/assets/bc17e2d6-50e3-4a13-a32d-d2f0aa4b16ae)
