### PR TITLE
Add missing __init__.py in utils package

### DIFF
--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+# Needed for Python to treat this directory as a package


### PR DESCRIPTION
adds the missing __init__.py file so that the utils folder is recognized as a package. This fixes potential import errors when using this module.

fix:
Traceback (most recent call last):
  File ".../main.py", line 3, in <module>
    import utils.settings as settings
ModuleNotFoundError: No module named 'utils.settings'