### PR TITLE
Correctly end sessions when players disconnect

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,4 +1,4 @@
 SPHERE_NAME = "Project Sphere"
-SPHERE_VERSION = "1.3 Beta"
+SPHERE_VERSION = "1.3.1 Beta"
 SPHERE_MESSAGE = f"Running {SPHERE_NAME} v{SPHERE_VERSION}"
 SPHERE_THUMBNAIL = "https://www.palbot.gg/assets/images/rexavatar.png"


### PR DESCRIPTION
Addresses an issue where player sessions were not properly terminated upon disconnection, leading to continuous accumulation of playtime on said players.

Previously, the `server_online_cache` was updated before identifying disconnected players, causing the system to overlook session terminations. This fix ensures accurate playtime tracking by retrieving the previous set of online players before updating the cache, comparing the prior online players list with the current to detect disconnections and then properly ends the session tracking for players who are no longer connected.

